### PR TITLE
fix(routing-scope): missed additional context references

### DIFF
--- a/packages/router/src/routing-scope.ts
+++ b/packages/router/src/routing-scope.ts
@@ -105,9 +105,9 @@ export class RoutingScope {
       container = origin;
     } else {
       if ('context' in origin) {
-        container = origin.context;
+        container = (origin as any).container;
       } else if ('$controller' in origin) {
-        container = origin.$controller!.context;
+        container = origin.$controller!.container;
       } else {
         const controller = CustomElement.for(origin as Node, { searchParents: true });
         container = controller?.container;


### PR DESCRIPTION
Fixes up some more references to the now removed context.